### PR TITLE
EXAMPLE: Install block_info deb package in the validator docker image

### DIFF
--- a/validator/Dockerfile-installed-bionic
+++ b/validator/Dockerfile-installed-bionic
@@ -183,6 +183,42 @@ RUN dpkg -i /tmp/python3-sawtooth-*.deb || true \
  && if [ -d "packaging/ubuntu" ]; then cp -R packaging/ubuntu/* debian/; fi \
  && dpkg-buildpackage -b -rfakeroot -us -uc
 
+# -------------=== block info tp build ===-------------
+
+FROM ubuntu:bionic as block-info-tp-builder
+
+RUN apt-get update \
+ && apt-get install gnupg -y
+
+ENV VERSION=AUTO_STRICT
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && apt-get install -y -q \
+    git \
+    python3 \
+    python3-colorlog \
+    python3-grpcio-tools \
+    python3-grpcio \
+    python3-protobuf \
+    python3-stdeb
+
+COPY --from=sawtooth-sdk-python-builder /project/sdk/python3-sawtooth-sdk*.deb /tmp
+
+COPY . /project
+
+RUN dpkg -i /tmp/python3-sawtooth-*.deb || true \
+ && apt-get -f -y install \
+ && /project/bin/protogen \
+ && cd /project/families/block_info/ \
+ && if [ -d "debian" ]; then rm -rf debian; fi \
+ && python3 setup.py clean --all \
+ && python3 setup.py --command-packages=stdeb.command debianize \
+ && if [ -d "packaging/ubuntu" ]; then cp -R packaging/ubuntu/* debian/; fi \
+ && dpkg-buildpackage -b -rfakeroot -us -uc
+
 # -------------=== sawtooth-validator docker build ===-------------
 FROM ubuntu:bionic
 
@@ -196,6 +232,8 @@ COPY --from=sawtooth-cli-builder /project/python3-sawtooth-cli*.deb /tmp
 COPY --from=sawtooth-sdk-python-builder /project/sdk/python3-sawtooth*.deb /tmp
 
 COPY --from=sawtooth-validator-builder /project/python3-sawtooth-validator*.deb /tmp
+
+COPY --from=block-info-tp-builder /project/families/python3-sawtooth-block-info*.deb /tmp
 
 RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \


### PR DESCRIPTION
The goal is to provide a self-contained validator Docker image
that is able to execute a validator with a block_info injector.

Signed-off-by: Benoit Razet <benoit.razet@pokitdok.com>